### PR TITLE
ci: add chktex lint step (informational)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: texlive/texlive:latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v6
+    - name: chktex
+      run: chktex -q tex/*.tex
+
   build:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## What
Adds a `chktex` lint job to the CI pipeline that runs on all `.tex` files.

## Why
Helps catch common LaTeX issues (missing `~` before `\ref`, wrong parentheses, etc.) early in PRs. Especially useful for external contributions.

## How
The lint job uses `continue-on-error: true` so it is informational only. Warnings are visible in the CI log but do not block the build. This allows us to gradually clean up existing warnings without breaking CI.